### PR TITLE
Add UTF-8 encoding at head of files to get build green (incompatible encoding regexp match)

### DIFF
--- a/lib/words_counted.rb
+++ b/lib/words_counted.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require "words_counted/version"
 require "words_counted/counter"
 

--- a/lib/words_counted/counter.rb
+++ b/lib/words_counted/counter.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module WordsCounted
   class Counter
     attr_reader :words, :word_occurrences, :word_lengths, :char_count

--- a/lib/words_counted/version.rb
+++ b/lib/words_counted/version.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module WordsCounted
   VERSION = "0.1.4"
 end


### PR DESCRIPTION
bundle exec rake failed before my pull request like this:

```
1) WordsCounted::Counter words does not split on unicode chars
  Failure/Error: counter = Counter.new("S?o Paulo")
  Encoding::CompatibilityError:
    incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)
  # ./lib/words_counted/counter.rb:16:in `scan'
  # ./lib/words_counted/counter.rb:16:in `initialize'
  # ./spec/words_counted/counter_spec.rb:55:in `new'
  # ./spec/words_counted/counter_spec.rb:55:in `block (3 levels) in <module:WordsCounted>'
```
